### PR TITLE
update the Dockerfile

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ The first stage copies the [hotspot=copyJar]`guide-spring-boot-0.1.0.jar` Spring
 and then uses the Open Liberty [hotspot=springBootUtility]`springBootUtility` command to thin the application. 
 For more information about the `springBootUtility` command, see the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[springBootUtility documentation^].
 
-The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` file from the `/opt/ol/wlp/templates` directory. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file. The `lib.index.cache` directory and the `thin-guide-spring-boot-0.1.0.jar` file were both generated in the first stage.
+The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` file from the `/opt/ol/wlp/templates` directory, which enables Spring Boot and TLS support. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file. The `lib.index.cache` directory and the `thin-guide-spring-boot-0.1.0.jar` file were both generated in the first stage.
 
 Use the following command to build the Docker image:
 [role='command']

--- a/README.adoc
+++ b/README.adoc
@@ -96,8 +96,8 @@ The first stage copies the [hotspot=copyJar]`guide-spring-boot-0.1.0.jar` Spring
 and then uses the Open Liberty [hotspot=springBootUtility]`springBootUtility` command to thin the application. 
 For more information about the `springBootUtility` command, see the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[springBootUtility documentation^].
 
-The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. Then, the Dockerfile copies 
-the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` and
+The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies 
+the [hotspot=serverXml file=0]`server.xml` server configuration from templates. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` and
 the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file, both of which were generated in the first stage.
 
 Use the following command to build the Docker image:

--- a/README.adoc
+++ b/README.adoc
@@ -97,7 +97,7 @@ and then uses the Open Liberty [hotspot=springBootUtility]`springBootUtility` co
 For more information about the `springBootUtility` command, see the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[springBootUtility documentation^].
 
 The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies 
-the [hotspot=serverXml file=0]`server.xml` server configuration from templates. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` and
+the [hotspot=serverXml file=0]`server.xml` server configuration from `/opt/ol/wlp/templates` directory. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` directory and
 the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file, both of which were generated in the first stage.
 
 Use the following command to build the Docker image:

--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ The first stage copies the [hotspot=copyJar]`guide-spring-boot-0.1.0.jar` Spring
 and then uses the Open Liberty [hotspot=springBootUtility]`springBootUtility` command to thin the application. 
 For more information about the `springBootUtility` command, see the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[springBootUtility documentation^].
 
-The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` server configuration from the `/opt/ol/wlp/templates` directory. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at the [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file, both of which were generated in the first stage.
+The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` file from the `/opt/ol/wlp/templates` directory. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file. The `lib.index.cache` directory and the `thin-guide-spring-boot-0.1.0.jar` file were both generated in the first stage.
 
 Use the following command to build the Docker image:
 [role='command']

--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ The first stage copies the [hotspot=copyJar]`guide-spring-boot-0.1.0.jar` Spring
 and then uses the Open Liberty [hotspot=springBootUtility]`springBootUtility` command to thin the application. 
 For more information about the `springBootUtility` command, see the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[springBootUtility documentation^].
 
-The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` file from the `/opt/ol/wlp/templates` directory, which enables Spring Boot and TLS support. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file. The `lib.index.cache` directory and the `thin-guide-spring-boot-0.1.0.jar` file were both generated in the first stage.
+The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` file from the `/opt/ol/wlp/templates` directory, which enables Spring Boot and TLS support. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at the [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file. The `lib.index.cache` directory and the `thin-guide-spring-boot-0.1.0.jar` file were both generated in the first stage.
 
 Use the following command to build the Docker image:
 [role='command']

--- a/README.adoc
+++ b/README.adoc
@@ -96,9 +96,7 @@ The first stage copies the [hotspot=copyJar]`guide-spring-boot-0.1.0.jar` Spring
 and then uses the Open Liberty [hotspot=springBootUtility]`springBootUtility` command to thin the application. 
 For more information about the `springBootUtility` command, see the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[springBootUtility documentation^].
 
-The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies 
-the [hotspot=serverXml file=0]`server.xml` server configuration from `/opt/ol/wlp/templates` directory. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at [hotspot=libcache file=0]`lib.index.cache` directory and
-the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file, both of which were generated in the first stage.
+The second stage begins with the [hotspot=OLimage2 file=0]`Open Liberty Docker image`. The Dockerfile copies the [hotspot=serverXml file=0]`server.xml` server configuration from the `/opt/ol/wlp/templates` directory. Then, the Dockerfile copies the Spring Boot dependent library JAR files that are at the [hotspot=libcache file=0]`lib.index.cache` directory and the [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` file, both of which were generated in the first stage.
 
 Use the following command to build the Docker image:
 [role='command']

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -17,9 +17,9 @@ RUN springBootUtility thin \
 # tag::OLimage2[]
 FROM open-liberty
 # end::OLimage2[]
-# tag::copyServerXml[]
+# tag::serverXml[]
 RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml
-# end::copyServerXml[]
+# end::serverXml[]
 # tag::libcache[]
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 # end::libcache[]

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -17,6 +17,9 @@ RUN springBootUtility thin \
 # tag::OLimage2[]
 FROM open-liberty
 # end::OLimage2[]
+# tag::copyServerXml[]
+RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml
+# end::copyServerXml[]
 # tag::libcache[]
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 # end::libcache[]

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -1,6 +1,6 @@
 # Stage and thin the application 
 # tag::OLimage1[]
-FROM open-liberty:springBoot2 as staging
+FROM open-liberty as staging
 # end::OLimage1[]
 # tag::copyJar[]
 COPY --chown=1001:0 target/guide-spring-boot-0.1.0.jar \
@@ -15,7 +15,7 @@ RUN springBootUtility thin \
 
 # Build the image
 # tag::OLimage2[]
-FROM open-liberty:springBoot2
+FROM open-liberty
 # end::OLimage2[]
 # tag::libcache[]
 COPY --from=staging /staging/lib.index.cache /lib.index.cache


### PR DESCRIPTION
`open-liberty:springBoot2` won't be updated with new fixpacks anymore, so need to use `open-liberty` image.