### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,9 @@
 :guide-author: Open Liberty
 = Containerizing, packaging, and running a Spring Boot application
 
+[.hidden]
+NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].
+
 Learn how to containerize, package, and run a Spring Boot application on an Open Liberty server without modification.
 
 == What you'll learn


### PR DESCRIPTION
Cloud hosted guide misses the "What you'll learn" step