### PR TITLE
Update to use Spring Boot 3.1.3 and springBoot-3.0 feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 17
       - run: unset _JAVA_OPTIONS
       - name: Run tests
         run: sudo ../scripts/testApp.sh

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -37,7 +37,7 @@ LABEL \
   description="This image contains the hello application running with the Open Liberty runtime."
 
 # tag::serverXml[]
-RUN cp /opt/ol/wlp/templates/servers/springBoot2/server.xml /config/server.xml
+RUN cp /opt/ol/wlp/templates/servers/springBoot3/server.xml /config/server.xml
 # end::serverXml[]
 
 RUN features.sh

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>3.1.3</version>
   </parent>
 
   <dependencies>
@@ -44,7 +44,7 @@
   </dependencies>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>17</java.version>
   </properties>
 
   <build>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -3,10 +3,10 @@
 
     <featureManager>
     <!-- tag::servlet[] -->
-        <feature>servlet-4.0</feature>
+        <feature>servlet-6.0</feature>
     <!-- end::servlet[] -->
     <!-- tag::springboot[] -->
-        <feature>springBoot-2.0</feature>
+        <feature>springBoot-3.0</feature>
     <!-- end::springboot[] -->
     </featureManager>
 

--- a/finish/src/test/java/hello/HelloControllerIT.java
+++ b/finish/src/test/java/hello/HelloControllerIT.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.springframework</groupId>
@@ -10,7 +9,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>3.1.3</version>
   </parent>
 
   <dependencies>
@@ -45,7 +44,7 @@
   </dependencies>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>17</java.version>
   </properties>
 
   <build>

--- a/start/src/test/java/hello/HelloControllerIT.java
+++ b/start/src/test/java/hello/HelloControllerIT.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 


### PR DESCRIPTION
This PR cannot be used until the `springBoot-3.0` feature is published as a GA feature.