### PR TITLE
Revert "Bump org.springframework.boot:spring-boot-starter-parent from 3.4.5 to 3.5.0 in /start"

### DIFF
--- a/start/pom.xml
+++ b/start/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>


### PR DESCRIPTION
Reverts OpenLiberty/guide-spring-boot#235